### PR TITLE
fix: update release.yml with settings to allow release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write    
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,6 +40,8 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v10.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: "github-actions"
+          git_committer_email: "actions@users.noreply.github.com"
           no_operation_mode: false  # enable real releases
           # verbosity: 2
           # strict: true


### PR DESCRIPTION
This pull request updates the release workflow configuration in `.github/workflows/release.yml` to ensure smoother automated releases and proper permissions. The main improvements involve setting the correct permissions for release jobs and specifying the committer identity for release commits.

Release workflow improvements:

* Added `contents: write` permission to the `release` job to allow publishing and modifying repository contents during the release process.
* Specified `git_committer_name` and `git_committer_email` for the release step to ensure commits are attributed to the `github-actions` bot, improving traceability and avoiding permission issues.