### PR TITLE
ci: gate release on tests and split workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,47 +1,37 @@
-name: Release
-
+name: Semantic Release
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
 
 jobs:
-  test:
+  semantic-release:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0   # full history for version calc
-          fetch-tags: true # ensure tags are available
-      - uses: astral-sh/setup-uv@v3
-      - name: Install deps
-        run: uv sync
-      - name: Lint (ruff)
-        run: uv run ruff check .
-      - name: Type check (ty)
-        run: uv run ty check .
-
-  release:
-    runs-on: ubuntu-latest
-    needs: test
-    permissions:
-      contents: write    
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: astral-sh/setup-uv@v3
-      - name: Update lockfile
-        run: uv lock
-      - name: Semantic Release (noop)
-        uses: python-semantic-release/python-semantic-release@v10.2.0
+          persist-credentials: false
+
+      - name: Configure git author
+        run: |
+          git config user.name "release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+
+      - name: Use PAT for pushes to origin
+        run: |
+          git remote set-url origin \
+            https://x-access-token:${{ secrets.SEMANTIC_RELEASE_PAT }}@github.com/${{ github.repository }}.git
+          # sanity check:
+          git ls-remote --heads origin >/dev/null
+
+      - name: Semantic Release
+        uses: python-semantic-release/python-semantic-release@v10
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_committer_name: "github-actions"
-          git_committer_email: "actions@users.noreply.github.com"
-          no_operation_mode: false  # enable real releases
-          # verbosity: 2
-          # strict: true
+          github_token: ${{ secrets.SEMANTIC_RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Semantic Release
+
 on:
-  push:
-    branches: ["main"]
+  workflow_run:
+    workflows: ["Run tests and linting"]
+    branches: [main]
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,6 +14,7 @@ permissions:
 
 jobs:
   semantic-release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Run tests and linting
 
 on:
   # Avoid duplicate runs: run on PRs for branches, and on direct pushes to main
@@ -39,3 +39,25 @@ jobs:
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false
+
+  lint:
+    name: Lint (uv + ruff + ty)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Sync dependencies (dev)
+        run: uv sync --all-extras --dev
+
+      - name: Run ruff lint
+        run: uv run ruff check .
+
+      - name: Run ty type checker
+        run: uv run ty check .


### PR DESCRIPTION
## Why?

Ensure releases only occur after tests pass on main and improve CI clarity.

## What Changed?

- Rename CI workflow to tests.yml and add separate lint job
- Update release workflow to use PAT, set author, secure git
- Gate release via workflow_run when tests conclude successfully on main

## Additional Notes

- Requires SEMANTIC_RELEASE_PAT repository secret with repo write access
- Tests workflow name: 'Run tests and linting'